### PR TITLE
fix for alternate_names table with mysql strict mode

### DIFF
--- a/src/Importer.php
+++ b/src/Importer.php
@@ -277,10 +277,10 @@ class Importer {
 				'name_id'        => $row[1],
 				'iso_language'   => $row[2],
 				'alternate_name' => $row[3],
-				'is_preferred'   => $row[4],
-				'is_short'       => $row[5],
-				'is_colloquial'  => $row[6],
-				'is_historic'    => $row[7],
+				'is_preferred'   => $row[4]? 1:0,
+				'is_short'       => $row[5]? 1:0,
+				'is_colloquial'  => $row[6]? 1:0,
+				'is_historic'    => $row[7]? 1:0,
 			);
 
 			$repository->insert($table, $insert);


### PR DESCRIPTION
These tinyint columns don't have a suitable default value, so the inserts fail when strict mode is enabled

```
mysql> describe geonames_alternate_names;
+----------------+------------------+------+-----+---------+----------------+
| Field          | Type             | Null | Key | Default | Extra          |
+----------------+------------------+------+-----+---------+----------------+
| id             | int(10) unsigned | NO   | PRI | NULL    | auto_increment |
| name_id        | int(11)          | NO   | MUL | NULL    |                |
| iso_language   | varchar(7)       | NO   |     | NULL    |                |
| alternate_name | varchar(200)     | NO   |     | NULL    |                |
| is_preferred   | tinyint(1)       | NO   | MUL | NULL    |                |
| is_short       | tinyint(1)       | NO   | MUL | NULL    |                |
| is_colloquial  | tinyint(1)       | NO   | MUL | NULL    |                |
| is_historic    | tinyint(1)       | NO   |     | NULL    |                |
+----------------+------------------+------+-----+---------+----------------+
```

This fix works fine, but we should probably also include a migration to change the defaults to `0`
