### PR TITLE
various column fixes

### DIFF
--- a/src/Importer.php
+++ b/src/Importer.php
@@ -95,8 +95,8 @@ class Importer {
 				'phone'                => $row[12],
 				'postal_code_format'   => $row[13],
 				'postal_code_regex'    => $row[14],
-				'name_id'              => $row[15],
-				'languages'            => $row[16],
+				'languages'            => $row[15],
+				'name_id'              => $row[16]? $row[16]:null,
 				'neighbours'           => $row[17],
 				'equivalent_fips_code' => $row[18],
 			);

--- a/src/migrations/2014_06_10_165833_geonames_defaults_and_nullables.php
+++ b/src/migrations/2014_06_10_165833_geonames_defaults_and_nullables.php
@@ -13,6 +13,9 @@ class GeonamesDefaultsAndNullables extends Migration {
     public function up()
     {
         DB::statement('ALTER TABLE geonames_names MODIFY COLUMN elevation INT DEFAULT NULL');
+        DB::statement('ALTER TABLE geonames_countries MODIFY COLUMN area DOUBLE DEFAULT NULL');
+        DB::statement('ALTER TABLE geonames_countries MODIFY COLUMN phone VARCHAR(32)');
+        DB::statement('ALTER TABLE geonames_countries MODIFY COLUMN name_id INT DEFAULT NULL');
     }
 
     /**
@@ -23,6 +26,9 @@ class GeonamesDefaultsAndNullables extends Migration {
     public function down()
     {
         DB::statement('ALTER TABLE geonames_names MODIFY COLUMN elevation INT NOT NULL');
+        DB::statement('ALTER TABLE geonames_countries MODIFY COLUMN area DOUBLE NOT NULL');
+        DB::statement('ALTER TABLE geonames_countries MODIFY COLUMN phone VARCHAR(10)');
+        DB::statement('ALTER TABLE geonames_countries MODIFY COLUMN name_id INT NOT NULL');
     }
 
 }


### PR DESCRIPTION
This includes various column fixes
- some columns were too short for the data
- some columns were not allowed to be null, which caused problems with mysql strict mode
- the countries importer had fields mapped to the wrong clumn index (`name_id` and `languages` switched)

(includes the original #15 pull request)
