### PR TITLE
use utf8mb4 for names and altnames

### DIFF
--- a/src/Importer.php
+++ b/src/Importer.php
@@ -2,6 +2,7 @@
 
 use Clousure;
 use RuntimeException;
+use DB;
 
 class Importer {
 
@@ -35,6 +36,7 @@ class Importer {
 		$this->isEmpty($table);
 
 		$repository = $this->repository;
+		DB::statement("SET NAMES 'utf8mb4'");
 
 		$this->parseFile($path, function($row) use ($table, $repository)
 		{
@@ -275,6 +277,7 @@ class Importer {
 		$this->isEmpty($table);
 
 		$repository = $this->repository;
+		DB::statement("SET NAMES 'utf8mb4'");
 
 		$this->parseFile($path, function($row) use ($table, $repository)
 		{

--- a/src/migrations/2014_06_10_234941_geonames_utf8mb4.php
+++ b/src/migrations/2014_06_10_234941_geonames_utf8mb4.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class GeonamesUtf8mb4 extends Migration {
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // requires MySQL >= 5.5
+        DB::statement('ALTER TABLE geonames_alternate_names CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+        DB::statement('ALTER TABLE geonames_alternate_names CHANGE alternate_name alternate_name VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+
+        DB::statement('ALTER TABLE geonames_names CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+        DB::statement('ALTER TABLE geonames_names CHANGE name name VARCHAR(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement('ALTER TABLE geonames_alternate_names CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci');
+        DB::statement('ALTER TABLE geonames_alternate_names CHANGE alternate_name alternate_name VARCHAR(200) CHARACTER SET utf8 COLLATE utf8_unicode_ci');
+
+        DB::statement('ALTER TABLE geonames_names CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci');
+        DB::statement('ALTER TABLE geonames_names CHANGE name name VARCHAR(200) CHARACTER SET utf8 COLLATE utf8_unicode_ci');
+    }
+}


### PR DESCRIPTION
The alternate_names data has utf8 characters that are longer than 3 bytes, so we need to change the character encoding and collation to `utf8mb4` - see [here](https://stackoverflow.com/questions/13653712/java-sql-sqlexception-incorrect-string-value-xf0-x9f-x91-xbd-xf0-x9f) and [here](https://dev.mysql.com/doc/refman/5.6/en/charset-unicode-utf8mb4.html). **This is a fix that requires mysql >= 5.5**

This is the error you get with `utf8`:

![selection_001](https://cloud.githubusercontent.com/assets/301091/3249219/9c4a5038-f196-11e3-82f0-4a14d84ed4c0.png)
