### PR TITLE
Fix value of 0 for primary key with non increment primary key

### DIFF
--- a/src/Eloquent/Continent.php
+++ b/src/Eloquent/Continent.php
@@ -5,6 +5,13 @@ use Illuminate\Database\Eloquent\Model;
 class Continent extends Model {
 
 	/**
+	 * Indicates if the IDs are auto-incrementing.
+	 *
+	 * @var bool
+	 */
+	public $incrementing = false;
+
+	/**
 	 * The table associated with the model.
 	 *
 	 * @var string

--- a/src/Eloquent/Country.php
+++ b/src/Eloquent/Country.php
@@ -5,6 +5,13 @@ use Illuminate\Database\Eloquent\Model;
 class Country extends Model {
 
 	/**
+	 * Indicates if the IDs are auto-incrementing.
+	 *
+	 * @var bool
+	 */
+	public $incrementing = false;
+
+	/**
 	 * The table associated with the model.
 	 *
 	 * @var string


### PR DESCRIPTION
In Laravel 5.2, I have an issue when I try to get the primary key value from Country and Continent. It seems the value is cast to int because of increment property set to true.