### PR TITLE
Sync deps with Laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     }
   ],
   "require": {
-    "php": ">=5.5.9",
+    "php": ">=5.6.4",
     "ext-zip": "*",
-    "illuminate/config": ">=5.4.0",
-    "illuminate/console": ">=5.4.0",
-    "illuminate/database": ">=5.4.0",
-    "illuminate/filesystem": ">=5.4.0",
-    "illuminate/support": ">=5.4.0",
-    "symfony/process": "3.2.*"
+    "illuminate/config": "~5.4",
+    "illuminate/console": "~5.4",
+    "illuminate/database": "~5.4",
+    "illuminate/filesystem": "~5.4",
+    "illuminate/support": "~5.4",
+    "symfony/process": "~3.2"
   },
   "require-dev": {
     "mockery/mockery": "0.9.*",


### PR DESCRIPTION
Laravel itself bump minimal PHP version in 5.4, so we can do so too.

Also `"symfony/process": "3.2.*"` require can lead to issues in some projects (see #33), so it should be in sync with Laravel style (`~3.2`) and allow usage of newer versions of the library.